### PR TITLE
Add `SignalRouter` to replace `make_signal_handler` and `connect_signal_handler`

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -219,38 +219,6 @@ impl Drop for BuilderConnector {
     }
 }
 
-pub fn make_signal_handler<A, S>(
-    handler_name: &str,
-    ctx: &mut A::Context,
-) -> crate::RawSignalCallback 
-where
-    A: actix::Actor<Context = actix::Context<A>>,
-    A: actix::StreamHandler<S>,
-    S: crate::BuilderSignal,
-{
-    let (tx, rx) = mpsc::channel(16);
-    A::add_stream(rx, ctx);
-    S::bridge_signal(handler_name, tx, |_| None)
-        .ok_or_else(|| format!("Handler '{}' was requested, but only {:?} exist", handler_name, S::list_signals()))
-        .unwrap()
-}
-
-pub fn connect_signal_handler<A, S, O>(
-    object: &O,
-    gtk_signal_name: &str,
-    handler_name: &str,
-    ctx: &mut A::Context,
-) -> Result<glib::signal::SignalHandlerId, glib::error::BoolError>
-where
-    A: actix::Actor<Context = actix::Context<A>>,
-    A: actix::StreamHandler<S>,
-    S: crate::BuilderSignal,
-    O: glib::object::ObjectExt,
-{
-    let callback = make_signal_handler::<A, S>(handler_name, ctx);
-    object.connect_local(gtk_signal_name.as_ref(), false, callback)
-}
-
 pub struct ActorBuilder<'a, A: actix::Actor<Context = actix::Context<A>>> {
     builder_connector: &'a BuilderConnector,
     actor_context: A::Context,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -3,7 +3,6 @@ use core::convert::TryInto;
 use std::cell::RefCell;
 
 use gtk::Builder;
-use tokio::sync::mpsc;
 
 /// Holds instructions for generating a GTK builder.
 ///

--- a/src/builder_signal.rs
+++ b/src/builder_signal.rs
@@ -26,6 +26,12 @@ pub trait BuilderSignal: Sized + 'static {
 
 pub trait RegisterSignalHandlers {
     type MessageType;
+    type RouteSignals;
+
+    fn route_to<A>(self, ctx: &mut A::Context) -> Self::RouteSignals
+    where
+        A: actix::Actor<Context = actix::Context<A>>,
+        A: actix::StreamHandler<Self::MessageType>;
 
     fn register_signal_handlers<A>(self, ctx: &mut A::Context, callbacks: &mut HashMap<&'static str, crate::RawSignalCallback>)
     where
@@ -124,19 +130,82 @@ where
     I: SignalsInhibit<S>,
 {
     type MessageType = T::Output;
+    type RouteSignals = SignalRouter<S, I>;
+
+    fn route_to<A>(self, ctx: &mut A::Context) -> Self::RouteSignals
+    where
+        A: actix::Actor<Context = actix::Context<A>>,
+        A: actix::StreamHandler<Self::MessageType>
+    {
+        let Self { inhibit_dlg, transformer, .. } = self;
+
+        let (tx, rx) = mpsc::channel(16);
+
+        use tokio::stream::StreamExt;
+        let rx = rx.map(move|s| transformer.transform(s));
+        A::add_stream(rx, ctx);
+
+        SignalRouter { tx, inhibit_dlg }
+    }
 
     fn register_signal_handlers<A>(self, ctx: &mut A::Context, callbacks: &mut HashMap<&'static str, crate::RawSignalCallback>)
     where
         A: actix::Actor<Context = actix::Context<A>>,
         A: actix::StreamHandler<Self::MessageType>,
     {
-        let (tx, rx) = mpsc::channel(16);
+        let router = self.route_to::<A>(ctx);
+
         for signal in S::list_signals() {
-            let inhibit_dlg = self.inhibit_dlg.clone();
-            callbacks.insert(signal, S::bridge_signal(signal, tx.clone(), move |signal| inhibit_dlg.inhibit(signal)).unwrap());
+            if let Some(handler) = router.handler(signal) {
+                callbacks.insert(signal, handler);
+            } else {
+                panic!(
+                    "Got empty signal handler for {:?} even though it is listed in {:?}",
+                    signal, core::any::type_name::<S>(),
+                );
+            }
         }
-        use tokio::stream::StreamExt;
-        let rx = rx.map(move|s| self.transformer.transform(s));
-        A::add_stream(rx, ctx);
+    }
+}
+
+impl<S, T, I> BuilderSingalConnector<S, T, I>
+where
+    S: 'static,
+    S: BuilderSignal,
+    T: 'static,
+    T: SignalTransformer<S>,
+    I: 'static,
+    I: SignalsInhibit<S>,
+{
+    pub fn route_to<A>(self, ctx: &mut A::Context) -> <Self as RegisterSignalHandlers>::RouteSignals
+    where
+        A: actix::Actor<Context = actix::Context<A>>,
+        A: actix::StreamHandler<<Self as RegisterSignalHandlers>::MessageType>
+    {
+        <Self as RegisterSignalHandlers>::route_to::<A>(self, ctx)
+    }
+}
+
+pub struct SignalRouter<S, I>
+where
+    S: 'static,
+    S: BuilderSignal,
+    I: 'static,
+    I: SignalsInhibit<S>,
+{
+    tx: mpsc::Sender<S>,
+    inhibit_dlg: I,
+}
+
+impl<S, I> SignalRouter<S, I>
+where
+    S: 'static,
+    S: BuilderSignal,
+    I: 'static,
+    I: SignalsInhibit<S>,
+{
+    pub fn handler(&self, signal: &str) -> Option<crate::RawSignalCallback> {
+        let inhibit_dlg = self.inhibit_dlg.clone();
+        S::bridge_signal(signal, self.tx.clone(), move |signal| inhibit_dlg.inhibit(signal))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,6 +246,9 @@ pub enum Error {
     #[error(transparent)]
     XmlError(#[from] quick_xml::Error),
 
+    #[error(transparent)]
+    GtkBoolError(#[from] glib::BoolError),
+
     #[error("Builder is missing widget with ID {0:?}")]
     WidgetMissingInBuilder(String),
 
@@ -255,6 +258,9 @@ pub enum Error {
         expected_type: glib::types::Type,
         actual_type: glib::types::Type,
     },
+
+    #[error("{} does not have a signal named {0:?}")]
+    NoSuchSignalError(&'static str, String),
 }
 
 /// A message for removing actors along with their GUI

--- a/tests/connect_nonbuilder_signals.rs
+++ b/tests/connect_nonbuilder_signals.rs
@@ -13,7 +13,9 @@ mod util;
 enum TestSignal {
     Action1,
     Action2,
-    BlockAction(gio::SimpleAction, glib::Variant),
+    BlockAction(gio::SimpleAction, #[signal(variant)] String),
+    UnblockAction(gio::SimpleAction, #[signal(variant)] String),
+    DisconnectAction(gio::SimpleAction, #[signal(variant)] String),
 }
 
 struct TestActor {
@@ -26,6 +28,8 @@ impl actix::Actor for TestActor {
     type Context = actix::Context<Self>;
 
     fn started(&mut self, ctx: &mut Self::Context) {
+        let router = TestSignal::connector().route_to::<TestActor>(ctx);
+
         for (action_name, signal_name) in &[
             ("action1", "Action1"),
             ("action2", "Action2"),
@@ -34,13 +38,18 @@ impl actix::Actor for TestActor {
             self.action_group.add_action(&action);
             self.actions.insert(action_name, (
                     action.clone(),
-                    woab::connect_signal_handler::<TestActor, TestSignal, _>(&action, "activate", signal_name, ctx).unwrap(),
+                    action.connect_local("activate", false, router.handler(signal_name).unwrap()).unwrap(),
             ));
         }
-
-        let block_action = gio::SimpleAction::new("block", Some(&*String::static_variant_type()));
-        self.action_group.add_action(&block_action);
-        woab::connect_signal_handler::<TestActor, TestSignal, _>(&block_action, "activate", "BlockAction", ctx).unwrap();
+        for (action_name, signal_name) in &[
+            ("block", "BlockAction"),
+            ("unblock", "UnblockAction"),
+            ("disconnect", "DisconnectAction"),
+        ] {
+            let action = gio::SimpleAction::new(action_name, Some(&*String::static_variant_type()));
+            self.action_group.add_action(&action);
+            action.connect_local("activate", false, router.handler(signal_name).unwrap()).unwrap();
+        }
 
         self.output.borrow_mut().push("init");
     }
@@ -56,10 +65,19 @@ impl actix::StreamHandler<TestSignal> for TestActor {
                 self.output.borrow_mut().push("action2");
             },
             TestSignal::BlockAction(_, action) => {
-                let action = action.get::<String>().unwrap();
-                let (action, signal) = self.actions.remove(&*action).unwrap();
-                action.block_signal(&signal);
+                let (action, signal) = &self.actions[action.as_str()];
+                action.block_signal(signal);
                 self.output.borrow_mut().push("block");
+            }
+            TestSignal::UnblockAction(_, action) => {
+                let (action, signal) = &self.actions[action.as_str()];
+                action.unblock_signal(signal);
+                self.output.borrow_mut().push("unblock");
+            }
+            TestSignal::DisconnectAction(_, action) => {
+                let (action, signal) = self.actions.remove(&*action).unwrap();
+                action.disconnect(signal);
+                self.output.borrow_mut().push("disconnect");
             }
         }
     }
@@ -91,6 +109,16 @@ fn test_connect_nonbuilder_signals() -> anyhow::Result<()> {
     action_group.activate_action("action1", None);
     action_group.activate_action("action2", None);
     wait_for!(*output.borrow() == ["init", "action1", "action2", "block", "action2"])?;
+
+    action_group.activate_action("unblock", Some(&"action1".to_variant()));
+    wait_for!(*output.borrow() == ["init", "action1", "action2", "block", "action2", "unblock"])?;
+    action_group.activate_action("disconnect", Some(&"action2".to_variant()));
+    wait_for!(*output.borrow() == ["init", "action1", "action2", "block", "action2", "unblock", "disconnect"])?;
+
+    // We send both action2 and action1, but action2 is disconnected
+    action_group.activate_action("action2", None);
+    action_group.activate_action("action1", None);
+    wait_for!(*output.borrow() == ["init", "action1", "action2", "block", "action2", "unblock", "disconnect", "action1"])?;
 
     Ok(())
 }

--- a/tests/connect_nonbuilder_signals.rs
+++ b/tests/connect_nonbuilder_signals.rs
@@ -48,7 +48,7 @@ impl actix::Actor for TestActor {
         ] {
             let action = gio::SimpleAction::new(action_name, Some(&*String::static_variant_type()));
             self.action_group.add_action(&action);
-            action.connect_local("activate", false, router.handler(signal_name).unwrap()).unwrap();
+            router.connect(&action, "activate", signal_name).unwrap();
         }
 
         self.output.borrow_mut().push("init");


### PR DESCRIPTION
I ended up not using using fluent interface to connect multiple signals like I suggested in #11, because actions and widgets have separate `connect_local` methods that do not originate from the same trait. We probably bridge this with our own trait, but I'm not sure how I feel about doing so. At any rate it's not like `connect_signal_handler` could do it, so we are not losing functionality (sugar, actually) here.

Once this gets merged, I want to start closing the version. This mostly means bringing the docs and the tests (and the changelog - but this should not be **that** much work...) up to date, filling the missing parts when necessary. #5 and #7 will have to wait for 0.3 - 0.2 was delayed for long enough.