### PR TITLE
Add `#[derive(woab::PropSync)]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `#[derive(woab::PropSync)]` for generating getter and setter for relevant
+  widgets' properties.
 
 ## 0.4.0 - 2021-02-15
 ### Added

--- a/examples/example_prop_sync.glade
+++ b/examples/example_prop_sync.glade
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.38.2 -->
+<interface>
+  <requires lib="gtk+" version="3.24"/>
+  <object class="GtkAdjustment" id="adj_timer">
+    <property name="upper">100</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkApplicationWindow" id="win_app">
+    <property name="can-focus">False</property>
+    <signal name="destroy" handler="close" swapped="no"/>
+    <child>
+      <!-- n-columns=2 n-rows=2 -->
+      <object class="GtkGrid">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <child>
+          <object class="GtkSpinButton">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="input-purpose">number</property>
+            <property name="adjustment">adj_timer</property>
+          </object>
+          <packing>
+            <property name="left-attach">1</property>
+            <property name="top-attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">end</property>
+            <property name="label" translatable="yes">Timer:</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">end</property>
+            <property name="label" translatable="yes">Shortening:</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkEntry" id="txt_shortening">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+          </object>
+          <packing>
+            <property name="left-attach">1</property>
+            <property name="top-attach">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/examples/example_prop_sync.rs
+++ b/examples/example_prop_sync.rs
@@ -45,7 +45,7 @@ impl actix::Handler<Step> for WindowActor {
             adj_timer,
             mut txt_shortening,
         } = self.widgets.get_props();
-        if 0 < txt_shortening.len() {
+        if !txt_shortening.is_empty() {
             txt_shortening.remove(0);
         }
         self.widgets.set_props(&WindowWidgetsPropSetter {

--- a/examples/example_prop_sync.rs
+++ b/examples/example_prop_sync.rs
@@ -41,7 +41,10 @@ impl actix::Handler<Step> for WindowActor {
     type Result = ();
 
     fn handle(&mut self, _msg: Step, _ctx: &mut Self::Context) -> Self::Result {
-        let WindowWidgetsPropGetter { adj_timer, mut txt_shortening } = self.widgets.get_props();
+        let WindowWidgetsPropGetter {
+            adj_timer,
+            mut txt_shortening,
+        } = self.widgets.get_props();
         if 0 < txt_shortening.len() {
             txt_shortening.remove(0);
         }

--- a/examples/example_prop_sync.rs
+++ b/examples/example_prop_sync.rs
@@ -1,0 +1,91 @@
+use actix::prelude::*;
+use gtk::prelude::*;
+
+struct WindowActor {
+    widgets: WindowWidgets,
+}
+
+#[derive(woab::WidgetsFromBuilder, woab::PropSync)]
+struct WindowWidgets {
+    #[prop_sync("value": f64, get, set)]
+    adj_timer: gtk::Adjustment,
+    #[prop_sync(get, set)]
+    txt_shortening: gtk::Entry,
+}
+
+impl actix::Actor for WindowActor {
+    type Context = actix::Context<Self>;
+}
+
+impl actix::Handler<woab::Signal> for WindowActor {
+    type Result = woab::SignalResult;
+
+    fn handle(&mut self, msg: woab::Signal, _ctx: &mut Self::Context) -> Self::Result {
+        Ok(match msg.name() {
+            "close" => {
+                gtk::main_quit();
+                None
+            }
+            _ => msg.cant_handle()?,
+        })
+    }
+}
+
+struct Step;
+
+impl actix::Message for Step {
+    type Result = ();
+}
+
+impl actix::Handler<Step> for WindowActor {
+    type Result = ();
+
+    fn handle(&mut self, _msg: Step, _ctx: &mut Self::Context) -> Self::Result {
+        let WindowWidgetsPropGetter { adj_timer, mut txt_shortening } = self.widgets.get_props();
+        if 0 < txt_shortening.len() {
+            txt_shortening.remove(0);
+        }
+        self.widgets.set_props(&WindowWidgetsPropSetter {
+            adj_timer: adj_timer + 1.0,
+            txt_shortening: &txt_shortening,
+        });
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let factory = woab::BuilderFactory::from(std::fs::read_to_string("examples/example_prop_sync.glade")?);
+
+    gtk::init()?;
+    woab::run_actix_inside_gtk_event_loop()?;
+
+    woab::block_on(async {
+        factory.instantiate().connect_with(|bld| {
+            let win_app: gtk::ApplicationWindow = bld.get_object("win_app").unwrap();
+
+            win_app.show();
+            let addr = WindowActor {
+                widgets: bld.widgets().unwrap(),
+            }
+            .start();
+
+            actix::spawn({
+                use actix::clock::Instant;
+                let addr = addr.clone();
+                let mut next_step = Instant::now();
+                let step_duration = std::time::Duration::from_secs(1);
+                async move {
+                    loop {
+                        next_step += step_duration;
+                        actix::clock::sleep_until(next_step).await;
+                        addr.send(Step).await.unwrap();
+                    }
+                }
+            });
+
+            addr
+        });
+    });
+
+    gtk::main();
+    Ok(())
+}

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,7 +1,7 @@
 mod factories_derive;
 mod param_extraction;
-mod removable_derive;
 mod prop_sync_derive;
+mod removable_derive;
 mod util;
 mod widgets_from_builder_derive;
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,6 +1,7 @@
 mod factories_derive;
 mod param_extraction;
 mod removable_derive;
+mod prop_sync_derive;
 mod util;
 mod widgets_from_builder_derive;
 
@@ -35,6 +36,15 @@ pub fn derive_removable(input: proc_macro::TokenStream) -> proc_macro::TokenStre
 pub fn params(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = syn::parse_macro_input!(input as param_extraction::Input);
     match input.impl_param_extraction() {
+        Ok(output) => output.into(),
+        Err(error) => error.to_compile_error().into(),
+    }
+}
+
+#[proc_macro_derive(PropSync, attributes(prop_sync))]
+pub fn derive_prop_sync(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = syn::parse_macro_input!(input as syn::DeriveInput);
+    match prop_sync_derive::impl_prop_sync_derive(&input) {
         Ok(output) => output.into(),
         Err(error) => error.to_compile_error().into(),
     }

--- a/macros/src/prop_sync_derive.rs
+++ b/macros/src/prop_sync_derive.rs
@@ -1,0 +1,225 @@
+use crate::util::{iter_attrs_parts, path_to_single_string};
+use quote::{quote, quote_spanned};
+use syn::spanned::Spanned;
+use syn::parse::Error;
+
+pub fn impl_prop_sync_derive(ast: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, Error> {
+    let fields = if let syn::Data::Struct(syn::DataStruct {
+        fields: syn::Fields::Named(fields),
+        ..
+    }) = &ast.data
+    {
+        fields
+    } else {
+        return Err(Error::new_spanned(
+            ast,
+            "PropSync only supports structs with named fields",
+        ));
+    };
+    let mut fields_to_sync = Vec::new();
+    for field in fields.named.iter() {
+        let mut getter = false;
+        let mut setter = false;
+        let mut field_property = None;
+        iter_attrs_parts(&field.attrs, "prop_sync", |expr| {
+            match expr {
+                syn::Expr::Path(path) => {
+                    match path_to_single_string(&path.path)?.as_str() {
+                        "get" => {
+                            getter = true;
+                        }
+                        "set" => {
+                            setter = true;
+                        }
+                        _ => {
+                            return Err(Error::new_spanned(path, "unknown attribute"));
+                        }
+                    }
+                }
+                syn::Expr::Type(syn::ExprType {expr, ty, ..}) => {
+                    if let syn::Expr::Lit(syn::ExprLit {
+                        attrs: _,
+                        lit: syn::Lit::Str(property),
+                    }) = *expr {
+                        field_property = Some((property, *ty));
+                    } else {
+                        return Err(Error::new_spanned(expr, "expected a string literal (representing a GTK property)"));
+                    }
+                }
+                _ => {
+                    return Err(Error::new_spanned(expr, "illegal attribute option"));
+                }
+            }
+            Ok(())
+        })?;
+        if getter || setter {
+            fields_to_sync.push(FieldToSync {
+                ident: field.ident.as_ref().unwrap(),
+                ty: &field.ty,
+                property: field_property,
+                getter,
+                setter
+            });
+        }
+    }
+    let setter = gen_setter(ast, &fields_to_sync)?;
+    let getter = gen_getter(ast, &fields_to_sync)?;
+    Ok(quote! {
+        #setter
+        #getter
+    })
+}
+
+#[derive(Debug)]
+struct FieldToSync<'a> {
+    ident: &'a syn::Ident,
+    ty: &'a syn::Type,
+    property: Option<(syn::LitStr, syn::Type)>,
+    getter: bool,
+    setter: bool,
+}
+
+fn gen_setter(ast: &syn::DeriveInput, fields: &[FieldToSync]) -> Result<proc_macro2::TokenStream, Error> {
+    if !fields.iter().any(|f| f.setter) {
+        return Ok(quote!());
+    }
+
+    let struct_name = &ast.ident;
+    let setter_name = format!("{}PropSetter", struct_name);
+    let setter_name = syn::Ident::new(&setter_name, ast.ident.span());
+    let vis = &ast.vis;
+
+    let mut lifetime = None;
+
+    let mut struct_fields = Vec::new();
+    let mut prop_assignment = Vec::new();
+
+    for field in fields.iter() {
+        if !field.setter {
+            continue;
+        }
+        let ident = field.ident;
+        let field_type = field.ty;
+        if let Some((prop, ty)) = &field.property {
+            if let syn::Type::Reference(ty_ref) = ty {
+                let mut ty_ref = ty_ref.clone();
+                ty_ref.lifetime = Some(lifetime.get_or_insert_with(|| syn::Lifetime::new("'a", proc_macro2::Span::call_site())).clone());
+                struct_fields.push(quote! {
+                    #ident: #ty_ref
+                });
+            } else {
+                struct_fields.push(quote! {
+                    #ident: #ty
+                });
+            }
+            prop_assignment.push(quote! {
+                self.#ident.set_property(#prop, &setter.#ident)
+                    .expect(stringify!(cannot set #prop of #field_type));
+            });
+        } else {
+            let lifetime = lifetime.get_or_insert_with(|| syn::Lifetime::new("'a", proc_macro2::Span::call_site()));
+            let as_trait = quote_spanned! { field_type.span() =>
+                <#field_type as woab::prop_sync::SetProps<#lifetime>>
+            };
+            struct_fields.push(quote_spanned! { field_type.span() =>
+                #ident: #as_trait::SetterType
+            });
+            prop_assignment.push(quote_spanned! { field_type.span() =>
+                #as_trait::set_props(&self.#ident, &setter.#ident);
+            });
+        }
+    }
+
+    Ok(quote! {
+        #vis struct #setter_name <#lifetime> {
+            #(#struct_fields),*
+        }
+
+        impl<#lifetime> woab::prop_sync::SetProps<#lifetime> for #struct_name {
+            type SetterType = #setter_name<#lifetime>;
+
+            fn set_props(&self, setter: &Self::SetterType) {
+                #(#prop_assignment)*
+            }
+        }
+
+        impl #struct_name {
+            #vis fn set_props<#lifetime>(&self, setter: &#lifetime <Self as woab::prop_sync::SetProps<#lifetime>>::SetterType) {
+                <Self as woab::prop_sync::SetProps>::set_props(self, setter);
+            }
+        }
+    })
+}
+
+fn gen_getter(ast: &syn::DeriveInput, fields: &[FieldToSync]) -> Result<proc_macro2::TokenStream, Error> {
+    if !fields.iter().any(|f| f.getter) {
+        return Ok(quote!());
+    }
+
+    let struct_name = &ast.ident;
+    let getter_name = format!("{}PropGetter", struct_name);
+    let getter_name = syn::Ident::new(&getter_name, ast.ident.span());
+    let vis = &ast.vis;
+
+    let mut struct_fields = Vec::new();
+    let mut field_from_prop = Vec::new();
+
+    for field in fields.iter() {
+        if !field.getter {
+            continue;
+        }
+        let ident = field.ident;
+        let field_type = field.ty;
+        if let Some((prop, ty)) = &field.property {
+            if let syn::Type::Reference(ty_ref) = ty {
+                let ty = &ty_ref.elem;
+                struct_fields.push(quote! {
+                    #ident: <#ty as std::borrow::ToOwned>::Owned
+                });
+            } else {
+                struct_fields.push(quote! {
+                    #ident: #ty
+                });
+            }
+            field_from_prop.push(quote! {
+                #ident: self.#ident.get_property(#prop)
+                .expect(stringify!(no property #prop for #field_type))
+                    .get()
+                    .expect(stringify!(wrong type for #prop of #field_type))
+                    .expect(stringify!(#prop of #field_type is empty))
+            });
+        } else {
+            let as_trait = quote_spanned! { field_type.span() =>
+                <#field_type as woab::prop_sync::GetProps>
+            };
+            struct_fields.push(quote_spanned! { field_type.span() =>
+                #ident: #as_trait::GetterType
+            });
+            field_from_prop.push(quote_spanned! { field_type.span() =>
+                #ident: #as_trait::get_props(&self.#ident)
+            });
+        }
+    }
+
+    Ok(quote! {
+        #vis struct #getter_name {
+            #(#struct_fields),*
+        }
+
+        impl woab::prop_sync::GetProps for #struct_name {
+            type GetterType = #getter_name;
+
+            fn get_props(&self) ->  Self::GetterType {
+                #getter_name {
+                    #(#field_from_prop),*
+                }
+            }
+        }
+
+        impl #struct_name {
+            #vis fn get_props(&self) -> <Self as woab::prop_sync::GetProps>::GetterType {
+                <Self as woab::prop_sync::GetProps>::get_props(self)
+            }
+        }
+    })
+}

--- a/macros/src/prop_sync_derive.rs
+++ b/macros/src/prop_sync_derive.rs
@@ -113,7 +113,7 @@ fn gen_setter(ast: &syn::DeriveInput, fields: &[FieldToSync]) -> Result<proc_mac
                 });
             }
             prop_assignment.push(quote! {
-                self.#ident.set_property(#prop, &setter.#ident)
+                glib::ObjectExt::set_property(&self.#ident, #prop, &setter.#ident)
                     .expect(stringify!(cannot set #prop of #field_type));
             });
         } else {
@@ -182,7 +182,7 @@ fn gen_getter(ast: &syn::DeriveInput, fields: &[FieldToSync]) -> Result<proc_mac
                 });
             }
             field_from_prop.push(quote! {
-                #ident: self.#ident.get_property(#prop)
+                #ident: glib::ObjectExt::get_property(&self.#ident, #prop)
                 .expect(stringify!(no property #prop for #field_type))
                     .get()
                     .expect(stringify!(wrong type for #prop of #field_type))

--- a/macros/src/prop_sync_derive.rs
+++ b/macros/src/prop_sync_derive.rs
@@ -133,12 +133,18 @@ fn gen_setter(ast: &syn::DeriveInput, fields: &[FieldToSync]) -> Result<proc_mac
         }
     }
 
+    let lifetime_for_trait = if let Some(lifetime) = &lifetime {
+        lifetime.clone()
+    } else {
+        syn::Lifetime::new("'static", proc_macro2::Span::call_site())
+    };
+
     Ok(quote! {
         #vis struct #setter_name <#lifetime> {
             #(#struct_fields),*
         }
 
-        impl<#lifetime> woab::prop_sync::SetProps<#lifetime> for #struct_name {
+        impl<'a> woab::prop_sync::SetProps<'a> for #struct_name {
             type SetterType = #setter_name<#lifetime>;
 
             fn set_props(&self, setter: &Self::SetterType) {
@@ -147,7 +153,7 @@ fn gen_setter(ast: &syn::DeriveInput, fields: &[FieldToSync]) -> Result<proc_mac
         }
 
         impl #struct_name {
-            #vis fn set_props<#lifetime>(&self, setter: &#lifetime <Self as woab::prop_sync::SetProps<#lifetime>>::SetterType) {
+            #vis fn set_props<#lifetime>(&self, setter: &#lifetime <Self as woab::prop_sync::SetProps<#lifetime_for_trait>>::SetterType) {
                 <Self as woab::prop_sync::SetProps>::set_props(self, setter);
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,6 +117,7 @@ mod remove;
 mod signal;
 mod signal_routing;
 mod waking_helpers;
+pub mod prop_sync;
 
 /// Represent a set of GTK widgets created by a GTK builder.
 ///
@@ -254,6 +255,8 @@ pub use woab_macros::Removable;
 /// Parameters with types will be converted to that type, and untyped parameters will be
 /// `&glib::Value`.
 pub use woab_macros::params;
+
+pub use woab_macros::PropSync;
 
 pub use builder::*;
 pub use builder_dissect::dissect_builder_xml;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,11 +113,11 @@ mod builder;
 mod builder_dissect;
 mod error;
 mod event_loops_bridge;
+pub mod prop_sync;
 mod remove;
 mod signal;
 mod signal_routing;
 mod waking_helpers;
-pub mod prop_sync;
 
 /// Represent a set of GTK widgets created by a GTK builder.
 ///

--- a/src/prop_sync.rs
+++ b/src/prop_sync.rs
@@ -9,7 +9,7 @@ pub trait SetProps<'a> {
 pub trait GetProps {
     type GetterType;
 
-    fn get_props(&self) ->  Self::GetterType;
+    fn get_props(&self) -> Self::GetterType;
 }
 
 impl<'a> SetProps<'a> for gtk::Entry {
@@ -23,7 +23,7 @@ impl<'a> SetProps<'a> for gtk::Entry {
 impl GetProps for gtk::Entry {
     type GetterType = String;
 
-    fn get_props(&self) ->  Self::GetterType {
+    fn get_props(&self) -> Self::GetterType {
         self.get_text().to_string()
     }
 }

--- a/src/prop_sync.rs
+++ b/src/prop_sync.rs
@@ -1,0 +1,29 @@
+use gtk::prelude::*;
+
+pub trait SetProps<'a> {
+    type SetterType: 'a;
+
+    fn set_props(&self, setter: &Self::SetterType);
+}
+
+pub trait GetProps {
+    type GetterType;
+
+    fn get_props(&self) ->  Self::GetterType;
+}
+
+impl<'a> SetProps<'a> for gtk::Entry {
+    type SetterType = &'a str;
+
+    fn set_props(&self, setter: &Self::SetterType) {
+        self.set_text(setter);
+    }
+}
+
+impl GetProps for gtk::Entry {
+    type GetterType = String;
+
+    fn get_props(&self) ->  Self::GetterType {
+        self.get_text().to_string()
+    }
+}

--- a/src/prop_sync.rs
+++ b/src/prop_sync.rs
@@ -1,14 +1,26 @@
 use gtk::prelude::*;
 
+/// Set widgets values from some setter type. See [`#[derive(woab::PropSync)]`](crate::PropSync).
 pub trait SetProps<'a> {
+    /// The type of the setter.
+    ///
+    /// Usually a Rust primitive that implements `glib::value::ToValue` for widgets, or a generated
+    /// struct when generated from [`#[derive(woab::PropSync)]`](crate::PropSync).
     type SetterType: 'a;
 
+    /// Set the widgets' data from the setter type.
     fn set_props(&self, setter: &Self::SetterType);
 }
 
+/// Get widgets values into some getter type. See [`#[derive(woab::PropSync)]`](crate::PropSync).
 pub trait GetProps {
+    /// The type of the getter.
+    ///
+    /// Usually a Rust primitive that implements `glib::value::FromValueOptional` for widgets, or a
+    /// generated struct when generated from [`#[derive(woab::PropSync)]`](crate::PropSync).
     type GetterType;
 
+    /// Get the widgets' data into the getter type.
     fn get_props(&self) -> Self::GetterType;
 }
 

--- a/src/prop_sync.rs
+++ b/src/prop_sync.rs
@@ -24,6 +24,14 @@ pub trait GetProps {
     fn get_props(&self) -> Self::GetterType;
 }
 
+impl<'a> SetProps<'a> for gtk::Label {
+    type SetterType = &'a str;
+
+    fn set_props(&self, setter: &Self::SetterType) {
+        self.set_text(setter);
+    }
+}
+
 impl<'a> SetProps<'a> for gtk::Entry {
     type SetterType = &'a str;
 
@@ -37,5 +45,21 @@ impl GetProps for gtk::Entry {
 
     fn get_props(&self) -> Self::GetterType {
         self.get_text().to_string()
+    }
+}
+
+impl<'a> SetProps<'a> for gtk::CheckButton {
+    type SetterType = bool;
+
+    fn set_props(&self, setter: &Self::SetterType) {
+        self.set_active(*setter);
+    }
+}
+
+impl GetProps for gtk::CheckButton {
+    type GetterType = bool;
+
+    fn get_props(&self) -> Self::GetterType {
+        self.get_active()
     }
 }

--- a/tests/prop_sync.rs
+++ b/tests/prop_sync.rs
@@ -18,7 +18,7 @@ fn test_prop_sync() -> anyhow::Result<()> {
     gtk::init()?;
     woab::run_actix_inside_gtk_event_loop()?;
 
-    let widgets: TestWidgets = factory .instantiate().widgets()?;
+    let widgets: TestWidgets = factory.instantiate().widgets()?;
 
     widgets.text_entry.set_text("one");
     widgets.spin_button.set_value(2.0);

--- a/tests/prop_sync.rs
+++ b/tests/prop_sync.rs
@@ -37,7 +37,7 @@ fn test_prop_sync() -> anyhow::Result<()> {
     } = widgets.get_props();
 
     assert_eq!(text_entry, "one");
-    assert_eq!(spin_button, 2.0f64);
+    assert_eq!(spin_button as i64, 2);
     assert!(!check_button);
 
     widgets.set_props(&TestWidgetsPropSetter {
@@ -47,7 +47,7 @@ fn test_prop_sync() -> anyhow::Result<()> {
     });
 
     assert_eq!(widgets.text_entry.get_text(), "three");
-    assert_eq!(widgets.spin_button.get_value(), 4.0f64);
+    assert_eq!(widgets.spin_button.get_value_as_int(), 4);
     assert!(widgets.inner.check_button.get_active());
 
     Ok(())

--- a/tests/prop_sync.rs
+++ b/tests/prop_sync.rs
@@ -3,16 +3,23 @@ use gtk::prelude::*;
 #[derive(woab::WidgetsFromBuilder, woab::PropSync)]
 struct TestWidgets {
     #[prop_sync(set, get)]
-    text_entry: gtk::Entry,
-    #[prop_sync("value": f64, set, get)]
-    spin_button: gtk::SpinButton,
+    #[widget(nested)]
+    group1: WidgetsGroup1,
     #[prop_sync(set, get)]
     #[widget(nested)]
-    inner: InnerWidgets,
+    group2: WidgetsGroup2,
 }
 
 #[derive(woab::WidgetsFromBuilder, woab::PropSync)]
-struct InnerWidgets {
+struct WidgetsGroup1 {
+    #[prop_sync(set, get)]
+    text_entry: gtk::Entry,
+    #[prop_sync("value": f64, set, get)]
+    spin_button: gtk::SpinButton,
+}
+
+#[derive(woab::WidgetsFromBuilder, woab::PropSync)]
+struct WidgetsGroup2 {
     #[prop_sync("active": bool, set, get)]
     check_button: gtk::CheckButton,
 }
@@ -26,14 +33,13 @@ fn test_prop_sync() -> anyhow::Result<()> {
 
     let widgets: TestWidgets = factory.instantiate().widgets()?;
 
-    widgets.text_entry.set_text("one");
-    widgets.spin_button.set_value(2.0);
-    widgets.inner.check_button.set_active(false);
+    widgets.group1.text_entry.set_text("one");
+    widgets.group1.spin_button.set_value(2.0);
+    widgets.group2.check_button.set_active(false);
 
     let TestWidgetsPropGetter {
-        text_entry,
-        spin_button,
-        inner: InnerWidgetsPropGetter { check_button },
+        group1: WidgetsGroup1PropGetter { text_entry, spin_button },
+        group2: WidgetsGroup2PropGetter { check_button },
     } = widgets.get_props();
 
     assert_eq!(text_entry, "one");
@@ -41,14 +47,16 @@ fn test_prop_sync() -> anyhow::Result<()> {
     assert!(!check_button);
 
     widgets.set_props(&TestWidgetsPropSetter {
-        text_entry: "three",
-        spin_button: 4.0,
-        inner: InnerWidgetsPropSetter { check_button: true },
+        group1: WidgetsGroup1PropSetter {
+            text_entry: "three",
+            spin_button: 4.0,
+        },
+        group2: WidgetsGroup2PropSetter { check_button: true },
     });
 
-    assert_eq!(widgets.text_entry.get_text(), "three");
-    assert_eq!(widgets.spin_button.get_value_as_int(), 4);
-    assert!(widgets.inner.check_button.get_active());
+    assert_eq!(widgets.group1.text_entry.get_text(), "three");
+    assert_eq!(widgets.group1.spin_button.get_value_as_int(), 4);
+    assert!(widgets.group2.check_button.get_active());
 
     Ok(())
 }

--- a/tests/prop_sync.rs
+++ b/tests/prop_sync.rs
@@ -31,7 +31,7 @@ fn test_prop_sync() -> anyhow::Result<()> {
     } = widgets.get_props();
 
     assert_eq!(text_entry, "one");
-    assert_eq!(spin_button, 2.0);
+    assert_eq!(spin_button, 2.0f64);
     assert!(!check_button);
 
     widgets.set_props(&TestWidgetsPropSetter {
@@ -41,7 +41,7 @@ fn test_prop_sync() -> anyhow::Result<()> {
     });
 
     assert_eq!(widgets.text_entry.get_text(), "three");
-    assert_eq!(widgets.spin_button.get_value(), 4.0);
+    assert_eq!(widgets.spin_button.get_value(), 4.0f64);
     assert!(widgets.check_button.get_active());
 
     Ok(())

--- a/tests/prop_sync.rs
+++ b/tests/prop_sync.rs
@@ -32,7 +32,7 @@ fn test_prop_sync() -> anyhow::Result<()> {
 
     assert_eq!(text_entry, "one");
     assert_eq!(spin_button, 2.0);
-    assert_eq!(check_button, false);
+    assert!(!check_button);
 
     widgets.set_props(&TestWidgetsPropSetter {
         text_entry: "three",
@@ -42,7 +42,7 @@ fn test_prop_sync() -> anyhow::Result<()> {
 
     assert_eq!(widgets.text_entry.get_text(), "three");
     assert_eq!(widgets.spin_button.get_value(), 4.0);
-    assert_eq!(widgets.check_button.get_active(), true);
+    assert!(widgets.check_button.get_active());
 
     Ok(())
 }

--- a/tests/prop_sync.rs
+++ b/tests/prop_sync.rs
@@ -1,0 +1,48 @@
+use gtk::prelude::*;
+
+#[derive(woab::WidgetsFromBuilder, woab::PropSync)]
+struct TestWidgets {
+    // win_test: gtk::ApplicationWindow,
+    #[prop_sync(set, get)]
+    text_entry: gtk::Entry,
+    #[prop_sync("value": f64, set, get)]
+    spin_button: gtk::SpinButton,
+    #[prop_sync("active": bool, set, get)]
+    check_button: gtk::CheckButton,
+}
+
+#[test]
+fn test_prop_sync() -> anyhow::Result<()> {
+    let factory = woab::BuilderFactory::from(std::fs::read_to_string("tests/various_widgets.glade")?);
+
+    gtk::init()?;
+    woab::run_actix_inside_gtk_event_loop()?;
+
+    let widgets: TestWidgets = factory .instantiate().widgets()?;
+
+    widgets.text_entry.set_text("one");
+    widgets.spin_button.set_value(2.0);
+    widgets.check_button.set_active(false);
+
+    let TestWidgetsPropGetter {
+        text_entry,
+        spin_button,
+        check_button,
+    } = widgets.get_props();
+
+    assert_eq!(text_entry, "one");
+    assert_eq!(spin_button, 2.0);
+    assert_eq!(check_button, false);
+
+    widgets.set_props(&TestWidgetsPropSetter {
+        text_entry: "three",
+        spin_button: 4.0,
+        check_button: true,
+    });
+
+    assert_eq!(widgets.text_entry.get_text(), "three");
+    assert_eq!(widgets.spin_button.get_value(), 4.0);
+    assert_eq!(widgets.check_button.get_active(), true);
+
+    Ok(())
+}

--- a/tests/prop_sync.rs
+++ b/tests/prop_sync.rs
@@ -2,11 +2,17 @@ use gtk::prelude::*;
 
 #[derive(woab::WidgetsFromBuilder, woab::PropSync)]
 struct TestWidgets {
-    // win_test: gtk::ApplicationWindow,
     #[prop_sync(set, get)]
     text_entry: gtk::Entry,
     #[prop_sync("value": f64, set, get)]
     spin_button: gtk::SpinButton,
+    #[prop_sync(set, get)]
+    #[widget(nested)]
+    inner: InnerWidgets,
+}
+
+#[derive(woab::WidgetsFromBuilder, woab::PropSync)]
+struct InnerWidgets {
     #[prop_sync("active": bool, set, get)]
     check_button: gtk::CheckButton,
 }
@@ -22,12 +28,12 @@ fn test_prop_sync() -> anyhow::Result<()> {
 
     widgets.text_entry.set_text("one");
     widgets.spin_button.set_value(2.0);
-    widgets.check_button.set_active(false);
+    widgets.inner.check_button.set_active(false);
 
     let TestWidgetsPropGetter {
         text_entry,
         spin_button,
-        check_button,
+        inner: InnerWidgetsPropGetter { check_button },
     } = widgets.get_props();
 
     assert_eq!(text_entry, "one");
@@ -37,12 +43,12 @@ fn test_prop_sync() -> anyhow::Result<()> {
     widgets.set_props(&TestWidgetsPropSetter {
         text_entry: "three",
         spin_button: 4.0,
-        check_button: true,
+        inner: InnerWidgetsPropSetter { check_button: true },
     });
 
     assert_eq!(widgets.text_entry.get_text(), "three");
     assert_eq!(widgets.spin_button.get_value(), 4.0f64);
-    assert!(widgets.check_button.get_active());
+    assert!(widgets.inner.check_button.get_active());
 
     Ok(())
 }

--- a/tests/prop_sync.rs
+++ b/tests/prop_sync.rs
@@ -8,6 +8,8 @@ struct TestWidgets {
     #[prop_sync(set, get)]
     #[widget(nested)]
     group2: WidgetsGroup2,
+    #[prop_sync(set)]
+    label: gtk::Label,
 }
 
 #[derive(woab::WidgetsFromBuilder, woab::PropSync)]
@@ -20,7 +22,7 @@ struct WidgetsGroup1 {
 
 #[derive(woab::WidgetsFromBuilder, woab::PropSync)]
 struct WidgetsGroup2 {
-    #[prop_sync("active": bool, set, get)]
+    #[prop_sync(set, get)]
     check_button: gtk::CheckButton,
 }
 
@@ -36,6 +38,7 @@ fn test_prop_sync() -> anyhow::Result<()> {
     widgets.group1.text_entry.set_text("one");
     widgets.group1.spin_button.set_value(2.0);
     widgets.group2.check_button.set_active(false);
+    widgets.label.set_text("three");
 
     let TestWidgetsPropGetter {
         group1: WidgetsGroup1PropGetter { text_entry, spin_button },
@@ -48,15 +51,17 @@ fn test_prop_sync() -> anyhow::Result<()> {
 
     widgets.set_props(&TestWidgetsPropSetter {
         group1: WidgetsGroup1PropSetter {
-            text_entry: "three",
-            spin_button: 4.0,
+            text_entry: "four",
+            spin_button: 5.0,
         },
         group2: WidgetsGroup2PropSetter { check_button: true },
+        label: "six",
     });
 
-    assert_eq!(widgets.group1.text_entry.get_text(), "three");
-    assert_eq!(widgets.group1.spin_button.get_value_as_int(), 4);
+    assert_eq!(widgets.group1.text_entry.get_text(), "four");
+    assert_eq!(widgets.group1.spin_button.get_value_as_int(), 5);
     assert!(widgets.group2.check_button.get_active());
+    assert_eq!(widgets.label.get_text(), "six");
 
     Ok(())
 }

--- a/tests/various_widgets.glade
+++ b/tests/various_widgets.glade
@@ -10,7 +10,7 @@
   <object class="GtkApplicationWindow" id="win_test">
     <property name="can-focus">False</property>
     <child>
-      <!-- n-columns=1 n-rows=3 -->
+      <!-- n-columns=1 n-rows=4 -->
       <object class="GtkGrid">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
@@ -45,6 +45,16 @@
           <packing>
             <property name="left-attach">0</property>
             <property name="top-attach">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="label">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">3</property>
           </packing>
         </child>
       </object>

--- a/tests/various_widgets.glade
+++ b/tests/various_widgets.glade
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.38.2 -->
+<interface>
+  <requires lib="gtk+" version="3.24"/>
+  <object class="GtkAdjustment" id="adjustment1">
+    <property name="upper">100</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkApplicationWindow" id="win_test">
+    <property name="can-focus">False</property>
+    <child>
+      <!-- n-columns=1 n-rows=3 -->
+      <object class="GtkGrid">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <child>
+          <object class="GtkEntry" id="text_entry">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSpinButton" id="spin_button">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="adjustment">adjustment1</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkCheckButton" id="check_button">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">False</property>
+            <property name="draw-indicator">True</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">2</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>


### PR DESCRIPTION
This is an implementation of option 5 from #36 ("Generate intermediate struct and use it manually")