### PR TITLE
Close #41 - queue signals that are triggered inside the Actix runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [**BREAKING**] Upgraded gtk-rs to version 0.14. This is a breaking change
   because gtk-rs' API was changed in this release.
 - Updated Actix version to 0.12.
+- Code that triggers actor-handled signals is no longer required to trigger it
+  from outside the Actix runtime, as long as the signal does not expect an
+  inhibit decision and as long as it does not accept a context parameter.
 
 ### Added
 - `event_param` method for `woab::Signal`, to easily get the concrete GDK event

--- a/README.md
+++ b/README.md
@@ -25,10 +25,6 @@ demonstration.
 
 * When starting Actix actors from outside Tokio/Actix, `woab::block_on` must be
   used. This is a limitation of Actix that needs to be respected.
-* Some GTK actions (like removing a widget) can fire signals synchronously. If
-  these signals are registered as builder signals, WoAB will not be able to
-  route them and panic because it will happen while the Actix runtime is
-  occupied. To work around this, use `woab::spawn_outside`.
 * `dialog.run()` must not be used - use `woab::run_dialog` instead.
 * If an actor is created inside a `gtk::Application::connect_activate`, its
   `started` method will run **after** the `activate` signal is done. This can

--- a/examples/example_taggged_signals.rs
+++ b/examples/example_taggged_signals.rs
@@ -89,9 +89,9 @@ impl actix::Handler<woab::Signal<usize>> for WindowActor {
             "remove_addend" => {
                 if let Some((addend, _)) = self.addends.remove(msg.tag()) {
                     let lst_addition = self.widgets.lst_addition.clone();
-                    woab::spawn_outside(async move {
+                    // woab::spawn_outside(async move {
                         lst_addition.remove(&addend);
-                    });
+                    // });
                 }
                 None
             }

--- a/examples/example_taggged_signals.rs
+++ b/examples/example_taggged_signals.rs
@@ -89,9 +89,7 @@ impl actix::Handler<woab::Signal<usize>> for WindowActor {
             "remove_addend" => {
                 if let Some((addend, _)) = self.addends.remove(msg.tag()) {
                     let lst_addition = self.widgets.lst_addition.clone();
-                    // woab::spawn_outside(async move {
-                        lst_addition.remove(&addend);
-                    // });
+                    lst_addition.remove(&addend);
                 }
                 None
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,10 +106,6 @@
 //!
 //! * When starting Actix actors from outside Tokio/Actix, [`woab::block_on`](block_on) must be
 //!   used. This is a limitation of Actix that needs to be respected.
-//! * Some GTK actions (like removing a widget) can fire signals synchronously. If these signals
-//!   are registered as builder signals, WoAB will not be able to route them and panic because it
-//!   will happen while the Actix runtime is occupied. To work around this, use
-//!   [`woab::spawn_outside`](spawn_outside).
 //! * `dialog.run()` must not be used - use [`woab::run_dialog`](crate::run_dialog) instead.
 //! * If an actor is created inside a `gtk::Application::connect_activate`, its `started` method
 //!   will run **after** the `activate` signal is done. This can be a problem for methods like

--- a/src/signal_routing.rs
+++ b/src/signal_routing.rs
@@ -70,7 +70,7 @@ fn panic_if_signal_cannot_be_queued(signal_name: &str, parameters: &[glib::Value
 
 fn run_signal_routing_future(
     future: impl core::future::Future<Output = Result<Result<Option<gtk::Inhibit>, crate::Error>, actix::MailboxError>> + 'static,
-    signal_name: &Rc::<String>,
+    signal_name: &Rc<String>,
     parameters: &[glib::Value],
 ) -> Option<glib::Value> {
     match crate::try_block_on(future) {
@@ -84,7 +84,7 @@ fn run_signal_routing_future(
             }
         }
         Err(future) => {
-            panic_if_signal_cannot_be_queued(&signal_name, parameters);
+            panic_if_signal_cannot_be_queued(signal_name, parameters);
             let signal_name = signal_name.clone();
             actix::spawn(async move {
                 let result = future.await.unwrap().unwrap();

--- a/src/signal_routing.rs
+++ b/src/signal_routing.rs
@@ -52,6 +52,59 @@ pub fn route_action(
     route_signal(action, signal, action.name().as_str(), target)
 }
 
+fn panic_if_signal_cannot_be_queued(signal_name: &str, parameters: &[glib::Value]) {
+    for (i, param) in parameters.iter().enumerate() {
+        let param_type = param.type_();
+        if param_type.name().ends_with("Context") {
+            panic!(
+                concat!(
+                    "Signal {:?}'s param at position {} is a {}. ",
+                    "Signals with context params cannot be invoked from inside the Actix runtime. ",
+                    "Try running whatever triggered it with `woab::outside()` or `woab::spawn_outside()",
+                ),
+                signal_name, i, param_type,
+            );
+        }
+    }
+}
+
+fn run_signal_routing_future(
+    future: impl core::future::Future<Output = Result<Result<Option<gtk::Inhibit>, crate::Error>, actix::MailboxError>> + 'static,
+    signal_name: &Rc::<String>,
+    parameters: &[glib::Value],
+) -> Option<glib::Value> {
+    match crate::try_block_on(future) {
+        Ok(result) => {
+            let result = result.unwrap().unwrap();
+            if let Some(gtk::Inhibit(inhibit)) = result {
+                use glib::value::ToValue;
+                Some(inhibit.to_value())
+            } else {
+                None
+            }
+        }
+        Err(future) => {
+            panic_if_signal_cannot_be_queued(&signal_name, parameters);
+            let signal_name = signal_name.clone();
+            actix::spawn(async move {
+                let result = future.await.unwrap().unwrap();
+                if let Some(result) = result {
+                    panic!(
+                        concat!(
+                            "Signal {:?}, was invoked inside the Actix runtime and had to be queued, ",
+                            "but it returned {:?} - which is not supported for queued signals. ",
+                            "Try running whatever triggered it with `woab::outside()` or `woab::spawn_outside()",
+                        ),
+                        signal_name.as_str(),
+                        result,
+                    );
+                }
+            });
+            None
+        }
+    }
+}
+
 #[doc(hidden)]
 pub trait GenerateRoutingGtkHandler {
     fn generate_routing_gtk_handler(&mut self, signal_name: &str) -> RawSignalCallback;
@@ -63,17 +116,7 @@ impl<T: Clone + 'static> GenerateRoutingGtkHandler for (T, actix::Recipient<crat
         let (tag, recipient) = self.clone();
         Box::new(move |parameters| {
             let signal = crate::Signal::new(signal_name.clone(), parameters.to_owned(), tag.clone());
-            let result = if let Ok(result) = crate::try_block_on(recipient.send(signal)) {
-                result.unwrap().unwrap()
-            } else {
-                panic!("Signal {:?} triggered from inside the Actix runtime. Try running whatever triggered it with `woab::spawn_outside()`", signal_name)
-            };
-            if let Some(gtk::Inhibit(inhibit)) = result {
-                use glib::value::ToValue;
-                Some(inhibit.to_value())
-            } else {
-                None
-            }
+            run_signal_routing_future(recipient.send(signal), &signal_name, parameters)
         })
     }
 }
@@ -295,17 +338,7 @@ impl<T: Clone + 'static> crate::GenerateRoutingGtkHandler for (T, NamespacedSign
         let tag = tag.clone();
         Box::new(move |parameters| {
             let signal = crate::Signal::new(signal_name.clone(), parameters.to_owned(), tag.clone());
-            let result = if let Ok(result) = crate::try_block_on(target.recipient.send(signal)) {
-                result.unwrap().unwrap()
-            } else {
-                panic!("Signal {:?} triggered from inside the Actix runtime. Try running whatever triggered it with `woab::spawn_outside()`", signal_name)
-            };
-            if let Some(gtk::Inhibit(inhibit)) = result {
-                use glib::value::ToValue;
-                Some(inhibit.to_value())
-            } else {
-                None
-            }
+            run_signal_routing_future(target.recipient.send(signal), &signal_name, parameters)
         })
     }
 }

--- a/src/waking_helpers.rs
+++ b/src/waking_helpers.rs
@@ -87,9 +87,18 @@ pub async fn wake_from_signal<T>(
 
 /// Run a future outside the Actix system.
 ///
-/// Useful for GTK operations that generate synchronous signals that are handled by actors. If
-/// these operations are executed inside the Actix runtime, they'll try to rerun the Actix runtime
-/// again to handle the signal - and fail. Therefore - they must be handled outside.
+/// If operation that generate GTK signals are executed inside the Actix runtime, they'll be
+/// queued to run later by the Actix event loop. This may be a problem if the signal is expecting
+/// an inhibit decision, because the handler will not be able to generate it before the signal
+/// returns. This may also be a problem for signals that use a context parameter (like `draw`),
+/// because by the time the handler is invoked the context will already expire. In such cases, the
+/// code that triggers the signal must run outside.
+///
+/// **Note**: Most GTK signals that have these requirements are already queued by GTK. This
+/// function was more useful before version 0.6 of WoAB , when signals were never queued by WoAB
+/// and all signals GTK handles immediately were required to run outside. Now it is not needed, but
+/// not deprecated either because the possibility of misbehaving custom signals cannot be ruled
+/// out.
 ///
 /// Similar to [`outside`], but returns immediately without waiting for the future to finish.
 ///
@@ -137,9 +146,18 @@ pub fn spawn_outside(fut: impl Future<Output = ()> + 'static) {
 
 /// Run a future outside the Actix runtime.
 ///
-/// Useful for GTK operations that generate synchronous signals that are handled by actors. If
-/// these operations are executed inside the Actix runtime, they'll try to rerun the Actix runtime
-/// again to handle the signal - and fail. Therefore - they must be handled outside.
+/// If operation that generate GTK signals are executed inside the Actix runtime, they'll be
+/// queued to run later by the Actix event loop. This may be a problem if the signal is expecting
+/// an inhibit decision, because the handler will not be able to generate it before the signal
+/// returns. This may also be a problem for signals that use a context parameter (like `draw`),
+/// because by the time the handler is invoked the context will already expire. In such cases, the
+/// code that triggers the signal must run outside.
+///
+/// **Note**: Most GTK signals that have these requirements are already queued by GTK. This
+/// function was more useful before version 0.6 of WoAB , when signals were never queued by WoAB
+/// and all signals GTK handles immediately were required to run outside. Now it is not needed, but
+/// not deprecated either because the possibility of misbehaving custom signals cannot be ruled
+/// out.
 ///
 /// Similar to [`spawn_outside`], but waits for the future to finish and returns its result.
 ///


### PR DESCRIPTION
Will panic if one of the signal parameters is a context, or if the
signal returns an inhibit decision.